### PR TITLE
Removed SafeArea from the screen to avoid ugly UI

### DIFF
--- a/packages/khalti_checkout_flutter/lib/src/widget/khalti_webview.dart
+++ b/packages/khalti_checkout_flutter/lib/src/widget/khalti_webview.dart
@@ -30,29 +30,30 @@ class _KhaltiWebViewState extends State<KhaltiWebView> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: ValueListenableBuilder(
-        valueListenable: showLinearProgressIndicator,
-        builder: (_, value, __) {
-          return Scaffold(
-            appBar: kIsWeb
-                ? null
-                : AppBar(
-                    title: const Text(s_payWithKhalti),
-                    actions: [
-                      IconButton(
-                        onPressed: _reload,
-                        icon: const Icon(Icons.refresh),
-                      )
-                    ],
-                    bottom: value
-                        ? const _LinearLoadingIndicator(
-                            color: Colors.deepPurple,
-                          )
-                        : null,
-                    elevation: 4,
-                  ),
-            body: StreamBuilder(
+    return ValueListenableBuilder(
+      valueListenable: showLinearProgressIndicator,
+      builder: (_, value, __) {
+        return Scaffold(
+          appBar: kIsWeb
+              ? null
+              : AppBar(
+                  title: const Text(s_payWithKhalti),
+                  actions: [
+                    IconButton(
+                      onPressed: _reload,
+                      icon: const Icon(Icons.refresh),
+                    )
+                  ],
+                  bottom: value
+                      ? const _LinearLoadingIndicator(
+                          color: Colors.deepPurple,
+                        )
+                      : null,
+                  elevation: 4,
+                ),
+          body: SafeArea(
+            top: false,
+            child: StreamBuilder(
               stream: connectivityUtil.internetConnectionListenableStatus,
               builder: (context, snapshot) {
                 if (!snapshot.hasData) return const SizedBox.shrink();
@@ -70,9 +71,9 @@ class _KhaltiWebViewState extends State<KhaltiWebView> {
                 }
               },
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Before and After Images

<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/khalti/checkout-sdk-flutter/assets/10810343/a867bad3-13df-4d11-a166-73596aacbfbb" alt="After Image" width="300"></td>
    <td><img src="https://github.com/khalti/checkout-sdk-flutter/assets/10810343/9e27e6c4-54f9-4f48-a946-2f17b51540b6" alt="Before Image" width="300"></td>
  </tr>
</table>
