### PR TITLE
fix: update appbar decoration to match khalti brand

### DIFF
--- a/packages/khalti_checkout_flutter/lib/src/widget/khalti_webview.dart
+++ b/packages/khalti_checkout_flutter/lib/src/widget/khalti_webview.dart
@@ -42,14 +42,13 @@ class _KhaltiWebViewState extends State<KhaltiWebView> {
           ? null
           : AppBar(
               title: const Text(s_payWithKhalti),
-              backgroundColor: Color(0xFFE8F0F7),
               actions: [
                 IconButton(
                   onPressed: _reload,
                   icon: const Icon(Icons.refresh),
                 )
               ],
-              elevation: 4,
+              elevation: 0,
             ),
       body: Column(
         children: [

--- a/packages/khalti_checkout_flutter/pubspec.yaml
+++ b/packages/khalti_checkout_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
-  flutter_inappwebview: ^6.1.5
+  flutter_inappwebview: ^6.2.0-beta.2
   http: ^1.3.0
   internet_connection_checker_plus: ^2.7.0
   khalti_checkout_core: ^1.0.0-dev.5


### PR DESCRIPTION
Currently payment page has white non-visible appbar which needs to be changed to something visible so added default khalti brand color.